### PR TITLE
[HDWG-49] 서버 인프라 배포 (Terraform + NCP Server)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,39 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.1"
+  hashes = [
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
+    "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
+    "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
+    "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",
+    "zh:37c92ec084d059d37d6cffdb683ccf68e3a5f8d2eb69dd73c8e43ad003ef8d24",
+    "zh:4269f01a98513651ad66763c16b268f4c2da76cc892ccfd54b401fff6cc11667",
+    "zh:51904350b9c728f963eef0c28f1d43e73d010333133eb7f30999a8fb6a0cc3d8",
+    "zh:73a66611359b83d0c3fcba2984610273f7954002febb8a57242bbb86d967b635",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ae387993a92bcc379063229b3cce8af7eaf082dd9306598fcd42352994d2de0",
+    "zh:9e0f365f807b088646db6e4a8d4b188129d9ebdbcf2568c8ab33bddd1b82c867",
+    "zh:b5263acbd8ae51c9cbffa79743fbcadcb7908057c87eb22fd9048268056efbc4",
+    "zh:dfcd88ac5f13c0d04e24be00b686d069b4879cc4add1b7b1a8ae545783d97520",
+  ]
+}
+
+provider "registry.terraform.io/navercloudplatform/ncloud" {
+  version = "3.1.1"
+  hashes = [
+    "h1:chqklf6nUiw+Fnz/9gPl1OgWaoXMSce4sB5gy78a5Tk=",
+    "zh:044eebba05159c70a5fe64d25a031d3e123e1dadbc828ef21534d8f8832a06ce",
+    "zh:1238597749795b15cf43c8cb5a04c4fbbbec4c68485c5fc2e1fa1b8fbdc03ce5",
+    "zh:27967a8ded9c605f11fde91a9387f253a4e83c13e1947217916ff6117beede0f",
+    "zh:2a0f640b26aa62579bf19ba3ccc2359293994aa8b7f128463b757a6804838841",
+    "zh:38ec8ec95ab3893123c041bfc73258c62ef53f4c2a7e3b3ad34c6faa363dc4d8",
+    "zh:4cfda34f2f042fff4ae5d820515e72ffb651a21012bedf7ce6fe2ef04594c632",
+    "zh:580839f2a955868fa669fd8ff51e4f3d8345d60c0ebd6571e6f3614d4e14beef",
+    "zh:67b068ec81f2c98edd585fbe13a7960b4d0cd462fc8c7dacfaaf2612164dfa24",
+    "zh:70e9c85114e126e0c9dd7df2bbd7ddcbe357f02a973584bc29e0fa5fea5218a3",
+    "zh:7b786b1cc4121c99d0333c13c48d9f7a7bc5ae0131b991591ffd8a2c753422f1",
+    "zh:afdc8ad37ca402fd3193e8aec025fbfe0323691e77312bb47a072a7861eb5e95",
+    "zh:fa0eee0cb5aee7b33c3c2ad5f77285894aa63620bf139ca8db84736e0e2a4654",
+    "zh:fdd043e7c015ae5daa18440750761c9ef8e55de64d35be436c4e618963aac86b",
+    "zh:fed0917e08ea529805015b092f0d9dc72bb2bb3f766f0860811abdf4249b26ab",
+  ]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -4,3 +4,14 @@ module "vpc" {
   zone         = var.zone
   service_name = var.service_name
 }
+
+
+module "server" {
+  source = "./modules/server"
+
+  zone         = var.zone
+  service_name = var.service_name
+
+  vpc_id    = module.vpc.vpc_id
+  subnet_id = module.vpc.subnet_id
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -27,3 +27,14 @@ module "load-balancer" {
   subnet_id               = module.vpc.subnet_id
   temp_server_instance_no = module.server.temp_server_instance_no
 }
+
+### Kubernetes로 이전할 때 주석 제거 
+# module "nks" {
+#   source = "./modules/nks"
+
+#   zone         = var.zone
+#   service_name = var.service_name
+
+#   vpc_id    = module.vpc.vpc_id
+#   subnet_id = module.vpc.subnet_id
+# }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -15,3 +15,15 @@ module "server" {
   vpc_id    = module.vpc.vpc_id
   subnet_id = module.vpc.subnet_id
 }
+
+module "load-balancer" {
+  source = "./modules/load-balancer"
+
+  zone         = var.zone
+  service_name = var.service_name
+  target_port  = var.facing_port
+
+  vpc_id                  = module.vpc.vpc_id
+  subnet_id               = module.vpc.subnet_id
+  temp_server_instance_no = module.server.temp_server_instance_no
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,6 @@
+module "vpc" {
+  source = "./modules/vpc"
+
+  zone         = var.zone
+  service_name = var.service_name
+}

--- a/infra/terraform/modules/load-balancer/load-balancer.tf
+++ b/infra/terraform/modules/load-balancer/load-balancer.tf
@@ -1,0 +1,46 @@
+
+resource "ncloud_lb" "alb" {
+  name           = "${var.service_name}-alb"
+  network_type   = "PUBLIC"
+  type           = "APPLICATION"
+  subnet_no_list = [var.subnet_id.public_lb]
+}
+
+resource "ncloud_lb_target_group" "alb-tg" {
+  name           = "${var.service_name}-alb-tg"
+  vpc_no         = var.vpc_id
+  protocol       = "HTTP"
+  target_type    = "VSVR"
+  port           = var.target_port
+  algorithm_type = "RR"
+  # TODO: Health Check configuration 추가
+  health_check {
+    protocol       = "HTTP"
+    http_method    = "GET"
+    port           = var.target_port
+    url_path       = "/"
+    cycle          = 30
+    up_threshold   = 2
+    down_threshold = 2
+  }
+}
+
+resource "ncloud_lb_listener" "alb-listener-http" {
+  load_balancer_no = ncloud_lb.alb.load_balancer_no
+  protocol         = "HTTP"
+  port             = 80
+  target_group_no  = ncloud_lb_target_group.alb-tg.target_group_no
+}
+
+### Domain 구매 + Certificate Manager로 tls 적용 후 주석 제거
+# resource "ncloud_lb_listener" "alb-listener-https" {
+#   load_balancer_no = ncloud_lb.alb.load_balancer_no
+#   protocol         = "HTTPS"
+#   port             = 443
+#   target_group_no  = ncloud_lb_target_group.alb-tg.target_group_no
+# }
+
+resource "ncloud_lb_target_group_attachment" "alb-tg-attachment" {
+  target_group_no = ncloud_lb_target_group.alb-tg.target_group_no
+  target_no_list  = [var.temp_server_instance_no]
+}

--- a/infra/terraform/modules/load-balancer/provider.tf
+++ b/infra/terraform/modules/load-balancer/provider.tf
@@ -1,0 +1,8 @@
+# Provider Configuration
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+}

--- a/infra/terraform/modules/load-balancer/variables.tf
+++ b/infra/terraform/modules/load-balancer/variables.tf
@@ -1,0 +1,7 @@
+variable "service_name" {}
+variable "zone" {}
+variable "target_port" {}
+
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "temp_server_instance_no" {}

--- a/infra/terraform/modules/nat/main.tf
+++ b/infra/terraform/modules/nat/main.tf
@@ -1,0 +1,7 @@
+# Resource: NAT Gateway
+resource "ncloud_nat_gateway" "nat-gateway" {
+  name      = "${var.service_name}-nat-gw"
+  zone      = var.zone
+  vpc_no    = var.vpc_id
+  subnet_no = var.subnet_id.public_nat
+}

--- a/infra/terraform/modules/nat/outputs.tf
+++ b/infra/terraform/modules/nat/outputs.tf
@@ -1,0 +1,7 @@
+output "nat_gw" {
+  value = {
+    id   = ncloud_nat_gateway.nat-gateway.id
+    ip   = ncloud_nat_gateway.nat-gateway.public_ip
+    name = ncloud_nat_gateway.nat-gateway.name
+  }
+}

--- a/infra/terraform/modules/nat/provider.tf
+++ b/infra/terraform/modules/nat/provider.tf
@@ -1,0 +1,8 @@
+# Provider Configuration
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+}

--- a/infra/terraform/modules/nat/variables.tf
+++ b/infra/terraform/modules/nat/variables.tf
@@ -1,0 +1,6 @@
+variable "service_name" {}
+variable "zone" {}
+
+variable "vpc_id" {}
+variable "subnet_id" {}
+

--- a/infra/terraform/modules/nks/main.tf
+++ b/infra/terraform/modules/nks/main.tf
@@ -1,0 +1,35 @@
+data "ncloud_nks_versions" "version" {
+  filter {
+    name   = "value"
+    values = ["1.27"]
+    regex  = true
+  }
+}
+
+resource "ncloud_login_key" "login-key" {
+  key_name = "${var.service_name}-login-key"
+}
+
+resource "ncloud_nks_cluster" "cluster" {
+  name                 = "${var.service_name}-cluster"
+  cluster_type         = "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
+  k8s_version          = data.ncloud_nks_versions.version.versions.0.value
+  login_key_name       = ncloud_login_key.login-key.key_name
+  lb_private_subnet_no = var.subnet_id.private_lb
+  lb_public_subnet_no  = var.subnet_id.public_lb
+  kube_network_plugin  = "cilium"
+  subnet_no_list       = [var.subnet_id.private_node]
+  vpc_no               = var.vpc_id
+  zone                 = var.zone
+  log {
+    audit = true
+  }
+}
+
+resource "ncloud_nks_node_pool" "node_pool" {
+  cluster_uuid   = ncloud_nks_cluster.cluster.uuid
+  node_pool_name = "${var.service_name}-node-pool"
+  node_count     = 2
+  product_code   = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
+  subnet_no_list = [var.subnet_id.private_node]
+}

--- a/infra/terraform/modules/nks/provider.tf
+++ b/infra/terraform/modules/nks/provider.tf
@@ -1,0 +1,8 @@
+# Provider Configuration
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+}

--- a/infra/terraform/modules/nks/variables.tf
+++ b/infra/terraform/modules/nks/variables.tf
@@ -1,0 +1,5 @@
+variable "service_name" {}
+variable "zone" {}
+
+variable "subnet_id" {}
+variable "vpc_id" {}

--- a/infra/terraform/modules/routing/main.tf
+++ b/infra/terraform/modules/routing/main.tf
@@ -1,0 +1,21 @@
+# Private Node Subnet의 Routing Table Cofiguration
+resource "ncloud_route_table" "rt-private-node" {
+  name                  = "${var.service_name}-private-node-rt"
+  description           = "Private Node Subnet의 Routing Table"
+  vpc_no                = var.vpc_id
+  supported_subnet_type = "PRIVATE"
+}
+
+resource "ncloud_route_table_association" "rt-association-private-node" {
+  route_table_no = ncloud_route_table.rt-private-node.id
+  subnet_no      = var.subnet_id.private_node
+}
+
+# Route Rule: Internet으로의 outbound traffic을 NAT GW에 연결
+resource "ncloud_route" "rt-route-private-node-nat" {
+  route_table_no         = ncloud_route_table.rt-private-node.id
+  destination_cidr_block = "0.0.0.0/0"
+  target_type            = "NATGW"
+  target_no              = var.nat_gw.id
+  target_name            = var.nat_gw.name
+}

--- a/infra/terraform/modules/routing/provider.tf
+++ b/infra/terraform/modules/routing/provider.tf
@@ -1,0 +1,8 @@
+# Provider Configuration
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+}

--- a/infra/terraform/modules/routing/variables.tf
+++ b/infra/terraform/modules/routing/variables.tf
@@ -1,0 +1,6 @@
+variable "service_name" {}
+variable "zone" {}
+
+variable "vpc_id" {}
+variable "nat_gw" {}
+variable "subnet_id" {}

--- a/infra/terraform/modules/server/acg.tf
+++ b/infra/terraform/modules/server/acg.tf
@@ -1,0 +1,37 @@
+resource "ncloud_access_control_group" "temp-server-acg" {
+  name        = "${var.service_name}-temp-server-acg"
+  description = "VPC Access Control Group"
+  vpc_no      = var.vpc_id
+}
+
+resource "ncloud_access_control_group_rule" "temp-server-acg-rule" {
+  access_control_group_no = ncloud_access_control_group.temp-server-acg.id
+
+  inbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "22"
+    description = "accept 22 port"
+  }
+
+  inbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "80"
+    description = "accept 80 port"
+  }
+
+  inbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "3000"
+    description = "accept 3000 port"
+  }
+
+  outbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "1-65535"
+    description = "accept 1-65535 port"
+  }
+}

--- a/infra/terraform/modules/server/init-script.tf
+++ b/infra/terraform/modules/server/init-script.tf
@@ -1,0 +1,19 @@
+resource "ncloud_init_script" "install-docker" {
+  name    = "${var.service_name}-install-docker"
+  content = <<-EOT
+    #!/usr/bin/env bash
+    # Update the system
+    sudo yum update -y
+
+    # Install Docker
+    sudo yum install -y yum-utils
+    sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    sudo yum install -y docker-ce docker-ce-cli containerd.io
+    sudo systemctl start docker
+    sudo systemctl enable docker
+
+    # Install Docker Compose
+    sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+  EOT
+}

--- a/infra/terraform/modules/server/main.tf
+++ b/infra/terraform/modules/server/main.tf
@@ -1,0 +1,46 @@
+resource "ncloud_login_key" "server-loginkey" {
+  key_name = "${var.service_name}-server-loginkey"
+}
+
+resource "local_file" "ssh_key" {
+  filename = "${ncloud_login_key.server-loginkey.key_name}.pem"
+  content  = ncloud_login_key.server-loginkey.private_key
+}
+
+resource "ncloud_server" "temp-server" {
+  subnet_no                 = var.subnet_id.public_node
+  name                      = "${var.service_name}-temp-server"
+  server_image_product_code = data.ncloud_server_image.server-image.id
+  server_product_code       = data.ncloud_server_product.server-product.id
+  login_key_name            = ncloud_login_key.server-loginkey.key_name
+  init_script_no            = ncloud_init_script.install-docker.id
+}
+
+resource "ncloud_public_ip" "temp-server-public-ip" {
+  server_instance_no = ncloud_server.temp-server.id
+}
+
+data "ncloud_server_image" "server-image" {
+  filter {
+    name   = "os_information"
+    values = ["CentOS 7.8 (64-bit)"]
+  }
+}
+
+data "ncloud_server_product" "server-product" {
+  server_image_product_code = data.ncloud_server_image.server-image.id
+
+  filter {
+    name   = "generation_code"
+    values = ["G2"]
+  }
+  filter {
+    name   = "product_type"
+    values = ["HICPU"]
+  }
+  filter {
+    name   = "product_name"
+    values = ["vCPU 2EA, Memory 4GB, Disk 50GB"]
+  }
+
+}

--- a/infra/terraform/modules/server/outputs.tf
+++ b/infra/terraform/modules/server/outputs.tf
@@ -1,0 +1,7 @@
+output "temp_server_instance_no" {
+  value = ncloud_server.temp-server.instance_no
+}
+
+output "temp_server_public_ip" {
+  value = ncloud_public_ip.temp-server-public-ip.public_ip
+}

--- a/infra/terraform/modules/server/provider.tf
+++ b/infra/terraform/modules/server/provider.tf
@@ -1,0 +1,8 @@
+# Provider Configuration
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+}

--- a/infra/terraform/modules/server/variables.tf
+++ b/infra/terraform/modules/server/variables.tf
@@ -1,0 +1,5 @@
+variable "service_name" {}
+variable "zone" {}
+
+variable "vpc_id" {}
+variable "subnet_id" {}

--- a/infra/terraform/modules/vpc/main.tf
+++ b/infra/terraform/modules/vpc/main.tf
@@ -1,0 +1,59 @@
+# Resource: VPC
+resource "ncloud_vpc" "main" {
+  name            = var.service_name
+  ipv4_cidr_block = var.cidr_block
+}
+
+# Resource: Subnet(Public - for Kube Node)
+resource "ncloud_subnet" "public-node" {
+  name           = "${var.service_name}-public-node"
+  vpc_no         = ncloud_vpc.main.id
+  subnet         = cidrsubnet(ncloud_vpc.main.ipv4_cidr_block, 8, 0)
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.main.default_network_acl_no
+  subnet_type    = "PUBLIC"
+  usage_type     = "GEN"
+}
+
+# Resource: Subnet(Public - for NAT Gateway)
+resource "ncloud_subnet" "public-nat" {
+  name           = "${var.service_name}-public-nat"
+  vpc_no         = ncloud_vpc.main.id
+  subnet         = cidrsubnet(ncloud_vpc.main.ipv4_cidr_block, 8, 1)
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.main.default_network_acl_no
+  subnet_type    = "PUBLIC"
+  usage_type     = "NATGW"
+}
+
+# Resource: Subnet(Public - for Load Balancer)
+resource "ncloud_subnet" "public-lb" {
+  name           = "${var.service_name}-public-lb"
+  vpc_no         = ncloud_vpc.main.id
+  subnet         = cidrsubnet(ncloud_vpc.main.ipv4_cidr_block, 8, 2)
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.main.default_network_acl_no
+  subnet_type    = "PUBLIC"
+  usage_type     = "LOADB"
+}
+
+# Resource: Subnet(Private - for Kube Node)
+resource "ncloud_subnet" "private-node" {
+  name           = "${var.service_name}-private"
+  vpc_no         = ncloud_vpc.main.id
+  subnet         = cidrsubnet(ncloud_vpc.main.ipv4_cidr_block, 8, 3)
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.main.default_network_acl_no
+  subnet_type    = "PRIVATE"
+}
+
+# Resource: Subnet(Private - for Load Balancer)
+resource "ncloud_subnet" "private-lb" {
+  name           = "${var.service_name}-private-lb"
+  vpc_no         = ncloud_vpc.main.id
+  subnet         = cidrsubnet(ncloud_vpc.main.ipv4_cidr_block, 8, 4)
+  zone           = var.zone
+  network_acl_no = ncloud_vpc.main.default_network_acl_no
+  subnet_type    = "PRIVATE"
+  usage_type     = "LOADB"
+}

--- a/infra/terraform/modules/vpc/outputs.tf
+++ b/infra/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  description = "VPC의 identifier"
+  value       = ncloud_vpc.main.id
+}
+
+output "subnet_id" {
+  description = "Subnet의 idnetifier"
+  value = {
+    public_node  = ncloud_subnet.public-node.id
+    public_lb    = ncloud_subnet.public-lb.id
+    public_nat   = ncloud_subnet.public-nat.id
+    private_node = ncloud_subnet.private-node.id
+    private_lb   = ncloud_subnet.private-lb.id
+  }
+}

--- a/infra/terraform/modules/vpc/provider.tf
+++ b/infra/terraform/modules/vpc/provider.tf
@@ -1,0 +1,8 @@
+# Provider Configuration
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+}

--- a/infra/terraform/modules/vpc/variables.tf
+++ b/infra/terraform/modules/vpc/variables.tf
@@ -1,0 +1,9 @@
+variable "service_name" {}
+variable "zone" {}
+
+variable "cidr_block" {
+  type        = string
+  description = "CIDR block range"
+  default     = "10.0.0.0/16"
+}
+

--- a/infra/terraform/provider.tf
+++ b/infra/terraform/provider.tf
@@ -1,0 +1,17 @@
+
+terraform {
+  required_providers {
+    ncloud = {
+      source = "NaverCloudPlatform/ncloud"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "ncloud" {
+  access_key  = var.ncp_access_key
+  secret_key  = var.ncp_secret_key
+  region      = "KR"
+  site        = "public"
+  support_vpc = true
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,24 @@
+variable "ncp_access_key" {
+  type = string
+}
+
+variable "ncp_secret_key" {
+  type = string
+}
+
+variable "service_name" {
+  type    = string
+  default = "imc"
+}
+
+variable "zone" {
+  type        = string
+  description = "availability zone"
+  default     = "KR-1"
+}
+
+variable "facing_port" {
+  type        = number
+  description = "Gateway service의 Port number"
+  default     = 3000
+}


### PR DESCRIPTION
## Issue Number
- 49 

## 작업 내용
Terraform을 이용해서 NCP의 자원을 정의합니다. 
NKS를 이용해서 Kubernetes를 좀 써보려고 했으나 ,, 시간이 없어 일단 인스턴스 띄우고 docker-compose로 배포하는 방식으로 합니다.

Terraform을 이용해 생성한 NCP 리소스는 다음과 같습니다. 

1. VPC * 1

2. subnet

2-1) public subnet * 3
  - kube node 용 (현재는 server instance가 위치함)
  - NAT gateway 용 (현재는 이용 x)
  - LB 용

2-2) private subnet * 2
  - kube node 용
  - LB 용

3. server (서버 인스턴스 사양: 월 6.6만원)
  - CPU 2EA
  - RAM 4GB
  - DISK 50GB

4. server script 
- 서버 인스턴스 활성화 시 docker 및 docker-compose 설치하는 script

5. L7 로드밸런서 (ALB) 

다음부터는 Kubernetes로 전환시 적용할 자원들입니다. (현재는 배포x) 

1. NAT Gateway
2. NAT를 위한 Route table
3. NKS
4. node pool 

## Reference

## Check List
