### PR TITLE
hotfix: Dockerfile 스크립트 수정 (공통 모듈 빌드)

### DIFF
--- a/apps/Dockerfile.app
+++ b/apps/Dockerfile.app
@@ -20,7 +20,7 @@ COPY . .
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 # Build shared libraries & Auth application
-RUN pnpm --filter "libs/*" build
+RUN pnpm --filter "@libs/*" build
 RUN pnpm --filter=$PKG_NAME build
 
 # Remove unnecessary dependencies from production


### PR DESCRIPTION
기존의 스크립트가 공통모듈을 찾지 못해 빌드 커맨드를 실행하지 않던 이슈가 있었음.
libs/* >> @libs/* 로 수정
