### PR TITLE
[hotfix] shared library 의존성 문제 해결 및 local에서 통합테스트를 위한 docker-compose 정의

### DIFF
--- a/apps/mail-integrator/src/google-api/google-api.module.ts
+++ b/apps/mail-integrator/src/google-api/google-api.module.ts
@@ -1,6 +1,6 @@
 import { Module, Scope } from '@nestjs/common';
 import { google } from 'googleapis';
-import { ConstantsModule } from 'libs/common';
+import { ConstantsModule } from '@libs/common';
 
 import { ProviderToken } from '../provider-tokens';
 import { GoogleMailFactory } from './google-mail.factory';

--- a/apps/mail-integrator/src/mail-integrator.module.ts
+++ b/apps/mail-integrator/src/mail-integrator.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { MailIntegratorController } from './mail-integrator.controller';
 import { MailIntegratorService } from './mail-integrator.service';
 import { GoogleApiModule } from './google-api/google-api.module';
-import { ConstantsModule } from 'libs/common';
+import { ConstantsModule } from '@libs/common';
 
 @Module({
   imports: [GoogleApiModule, ConstantsModule],

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,21 @@
 version: '3.8'
 
 services:
+  api-gateway:
+    image: 'hedwig/api-gateway'
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.app
+      args:
+        - PKG_NAME=@apps/api-gateway
+        - PORT=3000
+    container_name: api-gateway
+    env_file:
+      - .env
+    ports:
+      - '3000:3000'
+    restart: 'no'
+
   auth:
     image: 'hedwig/auth'
     build:
@@ -10,6 +25,53 @@ services:
         - PKG_NAME=@apps/auth
         - PORT=3000
     container_name: auth
+    env_file:
+      - .env
     ports:
-      - '3000:3000'
+      - '3001:3000'
+    restart: 'no'
+
+  inbox:
+    image: 'hedwig/inbox'
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.app
+      args:
+        - PKG_NAME=@apps/inbox
+        - PORT=3000
+    container_name: inbox
+    env_file:
+      - .env
+    ports:
+      - '3002:3000'
+    restart: 'no'
+
+  user:
+    image: 'hedwig/user'
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.app
+      args:
+        - PKG_NAME=@apps/hedwig
+        - PORT=3000
+    container_name: user
+    env_file:
+      - .env
+    ports:
+      - '3003:3000'
+    restart: 'no'
+
+  mail-integrator:
+    image: 'hedwig/mail-integrator'
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.app
+      args:
+        - PKG_NAME=@apps/mail-integrator
+        - PORT=3000
+    container_name: mail-integrator
+    env_file:
+      - .env
+    ports:
+      - '3004:3000'
     restart: 'no'


### PR DESCRIPTION
## Issue Number

## 작업 내용

[chore: local에서 실행할 docker-compose 정의](https://github.com/YAPP-Github/24th-Web-Team-2-BE/commit/6effc30ddccb86f8c919cc89a09c281959213295) 
docker-compose down
docker-compose up -d --build

실행하면 현재 우리 서비스를 로컬환경에서 통합테스팅할 수 있음.
물론 root directory에 .env로 환경변수를 작성해주어야 함

[chore: shared library 의존성 문제 해결](https://github.com/YAPP-Github/24th-Web-Team-2-BE/commit/fbe3f3a0cd7bc366cf1b234659ec9d6cbbb48de0) 
libs/common >> @libs/common

- libs/common으로 참조할 경우 pnpm이 상대경로로 찾아서 참조하기 때문에 프로젝트 빌드결과가 분리된 docker 환경에서는 참조 에러가 발생함.


## Reference

## Check List
