### PR TITLE
[HDWG-66] mail-integrator API 구현 (읽지 않은 메일 가져오기, 발신자 리스트 가져오기)

### DIFF
--- a/apps/mail-integrator/src/google-api/google-api.module.ts
+++ b/apps/mail-integrator/src/google-api/google-api.module.ts
@@ -28,6 +28,6 @@ import { MailContextService } from './mail-context.service';
       scope: Scope.REQUEST,
     },
   ],
-  exports: [GoogleMailManager],
+  exports: [GoogleMailManager, MailContextService],
 })
 export class GoogleApiModule {}

--- a/apps/mail-integrator/src/google-api/google-mail.client.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.client.ts
@@ -3,19 +3,24 @@ import { GoogleMailFactory } from './google-mail.factory';
 import { gmail_v1 } from 'googleapis';
 
 import gmailPageTokenCache from './caches/gmail-pageToken.cache';
+import { MailContextService } from './mail-context.service';
 
 @Injectable()
 export class GoogleMailClient {
-  constructor(private readonly googleMailFactory: GoogleMailFactory) {}
+  constructor(
+    private readonly googleMailFactory: GoogleMailFactory,
+    private readonly mailContextService: MailContextService,
+  ) {}
 
   async messages(): Promise<gmail_v1.Schema$Message[]> {
     const gmail = await this.googleMailFactory.gmail();
     const messageIdentifiers = await this.messageIdentifiers();
-    const messagePromise = messageIdentifiers.messages.map((message) => {
+    const messagePromise = messageIdentifiers.map((message) => {
       const res = gmail.users.messages.get({
         userId: 'me',
         id: message.id,
         format: 'full',
+        ...this.mailContextService.getMessagesFetchOption(),
       });
       return res;
     });
@@ -45,8 +50,10 @@ export class GoogleMailClient {
     const res = await gmail.users.messages.list({
       userId: 'me',
       pageToken: gmailPageTokenCache.get('userId'),
+      ...this.mailContextService.getMessagesListOption(),
     });
     gmailPageTokenCache.set('userId', res.data.nextPageToken);
-    return res.data;
+
+    return res.data.messages ?? [];
   }
 }

--- a/apps/mail-integrator/src/google-api/google-mail.parser.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.parser.ts
@@ -125,7 +125,7 @@ class MimeParser {
   }
 
   private getMimeHeader(target: string): string {
-    return this.message.payload.headers.find((header) => header.name === target).value;
+    return this.message.payload.headers.find((header) => header.name === target)?.value || '';
   }
 }
 

--- a/apps/mail-integrator/src/google-api/google-mail.querybuilder.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.querybuilder.ts
@@ -1,0 +1,70 @@
+export class GmailQueryBuilder {
+  private queryParts: string[] = [];
+
+  excludeFromDomains(domains: string[]): this {
+    if (domains && domains.length > 0) {
+      const domainList = domains.join(' ');
+      this.queryParts.push(`-from: {${domainList}}`);
+    }
+    return this;
+  }
+
+  includeFromDomains(domains: string[]): this {
+    if (domains && domains.length > 0) {
+      const domainList = domains.join(' ');
+      this.queryParts.push(`from: {${domainList}}`);
+    }
+    return this;
+  }
+
+  excludeLabels(labels: string[]): this {
+    if (labels && labels.length > 0) {
+      const labelList = labels.join(' ');
+      this.queryParts.push(`-label: {${labelList}}`);
+    }
+    return this;
+  }
+
+  includeLabels(labels: string[]): this {
+    if (labels && labels.length > 0) {
+      const labelList = labels.join(' ');
+      this.queryParts.push(`label: {${labelList}}`);
+    }
+    return this;
+  }
+
+  newerThan(value: number, unit: 'd' | 'm' | 'y'): this {
+    this.queryParts.push(`newer_than:${value}${unit}`);
+    return this;
+  }
+
+  olderThan(value: number, unit: 'd' | 'm' | 'y'): this {
+    this.queryParts.push(`older_than:${value}${unit}`);
+    return this;
+  }
+
+  and(): this {
+    if (this.queryParts.length > 0) {
+      this.queryParts.push('AND');
+    }
+    return this;
+  }
+
+  or(): this {
+    if (this.queryParts.length > 0) {
+      this.queryParts.push('OR');
+    }
+    return this;
+  }
+
+  not(): this {
+    if (this.queryParts.length > 0) {
+      this.queryParts.push('NOT');
+    }
+    return this;
+  }
+
+  buildQuery(): string {
+    return this.queryParts.join(' ');
+  }
+}

--- a/apps/mail-integrator/src/google-api/mail-context.service.ts
+++ b/apps/mail-integrator/src/google-api/mail-context.service.ts
@@ -1,14 +1,34 @@
 import { Injectable, Scope } from '@nestjs/common';
+import { gmail_v1 } from 'googleapis';
 
+// TODO: Context Service 더 안전하게 관리하도록 refactor...
 @Injectable({ scope: Scope.REQUEST })
 export class MailContextService {
   private _userId: string;
+  private messagesFetchOption: gmail_v1.Params$Resource$Users$Messages$Get;
+  private messagesListOption: gmail_v1.Params$Resource$Users$Messages$List;
 
   setUserId(userId: string) {
     this._userId = userId;
   }
 
+  setMessagesFetchOption(option: gmail_v1.Params$Resource$Users$Messages$Get) {
+    this.messagesFetchOption = option;
+  }
+
+  setMessagesListOption(option: gmail_v1.Params$Resource$Users$Messages$List) {
+    this.messagesListOption = option;
+  }
+
   getUserId() {
     return this._userId;
+  }
+
+  getMessagesFetchOption() {
+    return this.messagesFetchOption;
+  }
+
+  getMessagesListOption() {
+    return this.messagesListOption;
   }
 }

--- a/apps/mail-integrator/src/google-api/mail-fetch.policy.ts
+++ b/apps/mail-integrator/src/google-api/mail-fetch.policy.ts
@@ -1,26 +1,17 @@
 import { Message } from './google-mail.parser';
 
 export class MailFetchPolicy {
-  private readonly lastFetch: Date;
   private readonly fetchThreshold: Date;
-  private readonly designatedSenders: Set<string>;
   private flag: boolean;
 
-  constructor(configure: { lastFetch: Date; fetchThreshold: Date; senders: string[] }) {
+  constructor(configure: { fetchThreshold: Date }) {
     this.flag = true;
-    this.lastFetch = configure.lastFetch;
     this.fetchThreshold = configure.fetchThreshold;
-    this.designatedSenders = new Set();
-    configure.senders.forEach((sender) => this.designatedSenders.add(sender));
-  }
-
-  senderIncludeRule(sender: string) {
-    return this.designatedSenders.has(sender);
   }
 
   checkIfNext(message: Message) {
     try {
-      if (message.date < this.fetchThreshold || message.date < this.lastFetch) {
+      if (message.date < this.fetchThreshold) {
         this.flag = false;
       }
     } catch (e) {

--- a/apps/mail-integrator/src/mail-integrator.controller.ts
+++ b/apps/mail-integrator/src/mail-integrator.controller.ts
@@ -7,8 +7,43 @@ import { MessagePattern } from '@nestjs/microservices';
 export class MailIntegratorController {
   constructor(private readonly mailIntegratorService: MailIntegratorService) {}
 
-  @MessagePattern({ cmd: 'process-messages-onboarding' })
-  async processMessages(data: { userId: string }) {
-    await this.mailIntegratorService.processMessagesOnboarding(data.userId);
+  @MessagePattern({ cmd: 'get-mail-senders' })
+  async getMailSenders(data: { userId: string }) {
+    const result = await this.mailIntegratorService.getMailSenders(data.userId);
+    return {
+      senders: result.map((sender) => {
+        const { messageId, labels, ...rest } = sender;
+        return {
+          mailId: messageId,
+          ...rest,
+        };
+      }),
+    };
+  }
+
+  @MessagePattern({ cmd: 'get-unread-messages' })
+  async getUnreadMessages(data: { userId: string; type: 'SENDER' | 'GROUP' | 'ALL'; target?: string }) {
+    // TODO inbox API 호출
+    const inbox = {} as any; // user Id로 가져온 inbox 엔티티
+    let addresses = [];
+    switch (data.type) {
+      case 'SENDER':
+        addresses.push(data.target);
+      case 'GROUP':
+        addresses = inbox.groups.find((group) => group.name === data.target).senders.map((sender) => sender.address);
+      case 'ALL':
+        addresses = inbox.subscriptions.map((sub) => sub.address);
+    }
+
+    const messages = await this.mailIntegratorService.getUnreadMessages(data.userId, addresses);
+    return {
+      mails: messages.map((message) => {
+        const { messageId, labels, ...rest } = message;
+        return {
+          mailId: messageId,
+          ...rest,
+        };
+      }),
+    };
   }
 }

--- a/apps/mail-integrator/src/mail-integrator.service.ts
+++ b/apps/mail-integrator/src/mail-integrator.service.ts
@@ -1,19 +1,67 @@
 import { Injectable } from '@nestjs/common';
 import { MailFetchPolicy } from './google-api/mail-fetch.policy';
 import { GoogleMailManager } from './google-api/google-mail.manager';
+import { Message } from './google-api/google-mail.parser';
+import { MailContextService } from './google-api/mail-context.service';
+import { MailConstants } from '@libs/common';
+import { GmailQueryBuilder } from './google-api/google-mail.querybuilder';
 
 @Injectable()
 export class MailIntegratorService {
-  constructor(private readonly googleMailManager: GoogleMailManager) {}
+  constructor(
+    private readonly googleMailManager: GoogleMailManager,
+    private readonly mailContextService: MailContextService,
+    private readonly mailConsants: MailConstants,
+  ) {}
 
-  async processMessagesOnboarding(userId: string) {
-    // TODO: inbox API를 호출해서 하위의 값들을 채워넣는다.
-    const lastFetch = new Date();
-    const fetchThreshold = new Date();
-    const senders = [];
+  async getMailSenders(userId: string) {
+    this.mailContextService.setMessagesFetchOption({
+      userId: 'me',
+      format: 'full',
+    });
 
-    const policy = new MailFetchPolicy({ lastFetch, fetchThreshold, senders });
+    // TODO: date 설정 분리
+    const currentDate = new Date();
+    const fetchThreshold = new Date(currentDate);
+    fetchThreshold.setMonth(currentDate.getMonth() - 1);
 
-    await this.googleMailManager.processMessages(userId, policy);
+    const policy = new MailFetchPolicy({ fetchThreshold });
+
+    // 게인 메일 제외하기
+    const queryBuilder = new GmailQueryBuilder();
+    const query = queryBuilder.excludeFromDomains(this.mailConsants.privateMailDomains).and().newerThan(1, 'm').buildQuery();
+    this.mailContextService.setMessagesListOption({ q: query });
+
+    const senderMap = new Map<string, Message>();
+    for await (const messages of this.googleMailManager.retrieveMessages(userId, policy)) {
+      messages.forEach((message) => {
+        if (!senderMap.has(message.from.address)) {
+          senderMap.set(message.from.address, message);
+        }
+      });
+    }
+    return Array.from(senderMap.values());
+  }
+
+  async getUnreadMessages(userId: string, addresses: string[]) {
+    // TODO: date 설정 분리
+    const currentDate = new Date();
+    const fetchThreshold = new Date(currentDate);
+    fetchThreshold.setMonth(currentDate.getMonth() - 12);
+    this.mailContextService.setMessagesListOption({
+      userId: 'me',
+      labelIds: ['UNREAD'],
+    });
+
+    const policy = new MailFetchPolicy({ fetchThreshold });
+    const query = new GmailQueryBuilder().includeFromDomains(addresses).and().excludeLabels(['SENT']).and().newerThan(12, 'm').buildQuery();
+    this.mailContextService.setMessagesListOption({ q: query });
+
+    const msgs: Message[] = [];
+    for await (const messages of this.googleMailManager.retrieveMessages(userId, policy)) {
+      msgs.push(...messages);
+    }
+
+    return msgs;
   }
 }

--- a/libs/common/src/constants/constants.module.ts
+++ b/libs/common/src/constants/constants.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { MailConstants } from './mail.constants';
 import { designatedMailSenders } from './designatedMailSenders';
+import { privateMailDomains } from './privateMailDomains';
 
 @Module({
   providers: [
@@ -8,6 +9,10 @@ import { designatedMailSenders } from './designatedMailSenders';
     {
       provide: 'DESIGNATED_SENDERS',
       useValue: designatedMailSenders,
+    },
+    {
+      provide: 'PRIVATE_MAIL_DOMAINS',
+      useValue: privateMailDomains,
     },
   ],
   exports: [MailConstants],

--- a/libs/common/src/constants/mail.constants.ts
+++ b/libs/common/src/constants/mail.constants.ts
@@ -6,6 +6,8 @@ export class MailConstants {
   constructor(
     @Inject('DESIGNATED_SENDERS')
     private readonly designatedSenders: MailSender[],
+    @Inject('PRIVATE_MAIL_DOMAINS')
+    private readonly _privateMailDomains: string[],
   ) {}
 
   get designatedSenderAddresses() {
@@ -14,5 +16,9 @@ export class MailConstants {
 
   get designatedSenderAddressMap() {
     return new Map(this.designatedSenders.map((sender) => [sender.address, sender]));
+  }
+
+  get privateMailDomains() {
+    return this._privateMailDomains;
   }
 }

--- a/libs/common/src/constants/privateMailDomains.ts
+++ b/libs/common/src/constants/privateMailDomains.ts
@@ -1,0 +1,16 @@
+export const privateMailDomains: string[] = [
+  '@naver.com',
+  '@daum.net',
+  '@kakao.com',
+  '@gmail.com',
+  '@nate.com',
+  '@yahoo.co.kr',
+  '@yahoo.co.jp',
+  '@yahoo.co.ph',
+  '@yahoo.com',
+  '@hanmail.net',
+  '@outlook.com',
+  '@hotmail.com',
+  '@icloud.com',
+  '@ezweb.ne.jp',
+];


### PR DESCRIPTION
## Issue Number
- 66

## 작업 내용

### 이제 불필요한 메일을 걸러내는 `Policy` 역할을 대부분 google search query에 의존함

기존에는 원하는 발신자만 가져오거나, 원하지 않는 발신자를 제외하는 로직을 `Policy` 객체에 위임하여 수행했음.
하지만 google search query가 꽤 강력하고 효율적이더라 . . .  
Policy를 포기하는 대신 search query를 생성하는 책임의 QueryBuilder 클래스를 만들었고, `sender`, `label`, `date` 관련 필터링을 search query 단에서 미리 수행함.

** 아직 date 필터링을 로직 단에서도 수행하고 있긴한데 로직이 강결합되어있어서 지금 당장은 내버려두고 추후에 리팩토링할 예정

### Parser 로직 수정 
- 이제 from과 to 필드에 해당하는 raw text를 `name`과 `address`로 분리하여 제공하는 파싱 기능을 장착함.

### `get-mail-senders` 
- 유저가 gmail을 통해 1달 이내에 수신한 메일의 발신자를 groupby해서 배열 형태로 제공 (가장 최근 수신한 메일 본문도 같이)

### `get-unread-messages`
- 유저가 gmail을 통해 3달 이내 수신한 "읽지 않은" 메일을 조건에 맞게 (특정 group, sender query를 걸 수 있음) 배열 형태로 제공 


---

더 자세한 변경사항은 commit message 참고 ~

## Reference

## Check List
