### PR TITLE
[HDWG-66] 메일 읽음 & 읽지 않음 처리 API 구현 

### DIFF
--- a/apps/mail-integrator/src/google-api/google-mail.client.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.client.ts
@@ -51,6 +51,14 @@ export class GoogleMailClient {
     });
   }
 
+  async removeMessage(messageId: string): Promise<void> {
+    const gmail = await this.googleMailFactory.gmail();
+    await gmail.users.messages.trash({
+      userId: 'me',
+      id: messageId,
+    });
+  }
+
   async applyFilterBySender(from: string, labels: string[]) {
     const gmail = await this.googleMailFactory.gmail();
     gmail.users.settings.filters.create({

--- a/apps/mail-integrator/src/google-api/google-mail.client.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.client.ts
@@ -29,6 +29,28 @@ export class GoogleMailClient {
     return messages.map((message) => message.data);
   }
 
+  async addLabelsToMessage(messageId: string, labels: string[]): Promise<void> {
+    const gmail = await this.googleMailFactory.gmail();
+    await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        addLabelIds: labels,
+      },
+    });
+  }
+
+  async removeLabelsFromMessage(messageId: string, labels: string[]): Promise<void> {
+    const gmail = await this.googleMailFactory.gmail();
+    await gmail.users.messages.modify({
+      userId: 'me',
+      id: messageId,
+      requestBody: {
+        removeLabelIds: labels,
+      },
+    });
+  }
+
   async applyFilterBySender(from: string, labels: string[]) {
     const gmail = await this.googleMailFactory.gmail();
     gmail.users.settings.filters.create({

--- a/apps/mail-integrator/src/google-api/google-mail.manager.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.manager.ts
@@ -5,12 +5,14 @@ import { Message } from './google-mail.parser';
 
 import { MailContextService } from './mail-context.service';
 import gmailPageTokenCache from './caches/gmail-pageToken.cache';
+import { GoogleMailClient } from './google-mail.client';
 
 @Injectable()
 export class GoogleMailManager {
   constructor(
     private readonly googleMailReader: GoogleMailReader,
     private readonly mailContextService: MailContextService,
+    private readonly mailClient: GoogleMailClient,
   ) {}
 
   async *retrieveMessages(userId: string, mailPolicy: MailFetchPolicy) {
@@ -31,5 +33,15 @@ export class GoogleMailManager {
     }
     // TODO: token cache 일괄 관리하도록 수정
     gmailPageTokenCache.del('userId');
+  }
+
+  async modifyMessageAsRead(userId: string, messageId: string) {
+    this.mailContextService.setUserId(userId);
+    return await this.mailClient.removeLabelsFromMessage(messageId, ['UNREAD']);
+  }
+
+  async modifyMessageAsUnread(userId: string, messageId: string) {
+    this.mailContextService.setUserId(userId);
+    return await this.mailClient.addLabelsToMessage(messageId, ['UNREAD']);
   }
 }

--- a/apps/mail-integrator/src/google-api/google-mail.manager.ts
+++ b/apps/mail-integrator/src/google-api/google-mail.manager.ts
@@ -44,4 +44,9 @@ export class GoogleMailManager {
     this.mailContextService.setUserId(userId);
     return await this.mailClient.addLabelsToMessage(messageId, ['UNREAD']);
   }
+
+  async removeMessage(userId: string, messageId: string) {
+    this.mailContextService.setUserId(userId);
+    return await this.mailClient.removeMessage(messageId);
+  }
 }

--- a/apps/mail-integrator/src/mail-integrator.controller.ts
+++ b/apps/mail-integrator/src/mail-integrator.controller.ts
@@ -76,6 +76,12 @@ export class MailIntegratorController {
     };
   }
 
+  @MessagePattern({ cmd: 'remove-message' })
+  async removeMessage(data: { userId: string; mailId: string }) {
+    const res = await this.mailIntegratorService.removeMessage(data.userId, data.mailId);
+    return res;
+  }
+
   @MessagePattern({ cmd: 'modify-message-as-read' })
   async modifyMessageAsRead(data: { userId: string; mailId: string }) {
     const res = await this.mailIntegratorService.modifyMessageAsRead(data.userId, data.mailId);

--- a/apps/mail-integrator/src/mail-integrator.controller.ts
+++ b/apps/mail-integrator/src/mail-integrator.controller.ts
@@ -1,11 +1,22 @@
 import { Controller } from '@nestjs/common';
 
 import { MailIntegratorService } from './mail-integrator.service';
-import { MessagePattern } from '@nestjs/microservices';
+import { ClientProxy, ClientProxyFactory, MessagePattern, Transport } from '@nestjs/microservices';
+import { lastValueFrom } from 'rxjs';
 
 @Controller()
 export class MailIntegratorController {
-  constructor(private readonly mailIntegratorService: MailIntegratorService) {}
+  // URGENT: client proxy -> network client로 변경
+  private client: ClientProxy;
+  constructor(private readonly mailIntegratorService: MailIntegratorService) {
+    this.client = ClientProxyFactory.create({
+      transport: Transport.TCP,
+      options: {
+        host: process.env.INBOX_SERVICE_HOST,
+        port: parseInt(process.env.INBOX_SERVICE_PORT),
+      },
+    });
+  }
 
   @MessagePattern({ cmd: 'get-mail-senders' })
   async getMailSenders(data: { userId: string }) {
@@ -23,8 +34,26 @@ export class MailIntegratorController {
 
   @MessagePattern({ cmd: 'get-unread-messages' })
   async getUnreadMessages(data: { userId: string; type: 'SENDER' | 'GROUP' | 'ALL'; target?: string }) {
-    // TODO inbox API 호출
-    const inbox = {} as any; // user Id로 가져온 inbox 엔티티
+    // URGENT: inbox client 호출로 변경
+    const inbox = (await lastValueFrom(this.client.send({ cmd: 'get-inbox' }, { userId: data.userId }))) as {
+      inboxId: unknown;
+      subscriptions: {
+        name: string;
+        address: string;
+      }[];
+      groups: {
+        name: string;
+        senders: {
+          name: string;
+          address: string;
+        }[];
+      }[];
+      spams: string[];
+      interests: [string];
+      createdAt: Date;
+      updatedAt: Date;
+    };
+
     let addresses = [];
     switch (data.type) {
       case 'SENDER':

--- a/apps/mail-integrator/src/mail-integrator.controller.ts
+++ b/apps/mail-integrator/src/mail-integrator.controller.ts
@@ -46,4 +46,16 @@ export class MailIntegratorController {
       }),
     };
   }
+
+  @MessagePattern({ cmd: 'modify-message-as-read' })
+  async modifyMessageAsRead(data: { userId: string; mailId: string }) {
+    const res = await this.mailIntegratorService.modifyMessageAsRead(data.userId, data.mailId);
+    return res;
+  }
+
+  @MessagePattern({ cmd: 'modify-message-as-unread' })
+  async modifyMessageAsUnread(data: { userId: string; mailId: string }) {
+    const res = await this.mailIntegratorService.modifyMessageAsUnread(data.userId, data.mailId);
+    return res;
+  }
 }

--- a/apps/mail-integrator/src/mail-integrator.service.ts
+++ b/apps/mail-integrator/src/mail-integrator.service.ts
@@ -83,4 +83,8 @@ export class MailIntegratorService {
   async modifyMessageAsUnread(userId: string, messageId: string) {
     return await this.googleMailManager.modifyMessageAsUnread(userId, messageId);
   }
+
+  async removeMessage(userId: string, messageId: string) {
+    return await this.googleMailManager.removeMessage(userId, messageId);
+  }
 }

--- a/apps/mail-integrator/src/mail-integrator.service.ts
+++ b/apps/mail-integrator/src/mail-integrator.service.ts
@@ -75,4 +75,12 @@ export class MailIntegratorService {
 
     return msgs;
   }
+
+  async modifyMessageAsRead(userId: string, messageId: string) {
+    return await this.googleMailManager.modifyMessageAsRead(userId, messageId);
+  }
+
+  async modifyMessageAsUnread(userId: string, messageId: string) {
+    return await this.googleMailManager.modifyMessageAsUnread(userId, messageId);
+  }
 }


### PR DESCRIPTION
## Issue Number
- 66

## 작업 내용

특정 메일 (gmail api의 `messageId`로 식별)에 대해서 
 - 읽음 처리 (`UNREAD` 라벨 삭제) 
 - 읽지 않음 처리 (`UNREAD` 라벨 부착)

API를 구현했습니다.

## Reference

## Check List
