### PR TITLE
[hot-fix] lint staged가 dist 폴더에도 적용되는 이슈 해결

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js', 'package.json'],
+  ignorePatterns: ['.eslintrc.js', 'package.json', 'dist', 'node_modules'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+// .prettierignore
+dist
+package.json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "libs/*"
   ],
   "lint-staged": {
-    "*.{ts}": [
+    "*.ts": [
       "pnpm run format",
       "pnpm run lint"
     ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mail": "pnpm -F @apps/mail-integrator",
     "common": "pnpm -F @libs/common",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint --cache \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -28,11 +28,9 @@
     "libs/*"
   ],
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "eslint --fix"
-    ],
-    "package.json": [
-      "pnpm lint"
+    "*.{ts}": [
+      "pnpm run format",
+      "pnpm run lint"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Issue Number
hotfix

## 작업 내용
- eslint의 ignorePatterns에 dist, node_modules 포함
- prettier 또한 ignore에 dist, package.json, package-lock.json 포함

## Reference

## Check List
