### PR TITLE
[INSPO-117] 탐색 탭에서 뉴스레터 구독 리스트를 가져오는 API 구현

### DIFF
--- a/apps/api-gateway/src/api/inbox/inbox.controller.ts
+++ b/apps/api-gateway/src/api/inbox/inbox.controller.ts
@@ -37,4 +37,9 @@ export class InboxController {
     const { interests } = interestDTO;
     return await this.inboxService.addInterests(authInfo.userId, interests);
   }
+
+  @Get('/subscriptions-list')
+  async getSubscriptionsList() {
+    return await this.inboxService.getSubscriptionsList();
+  }
 }

--- a/apps/api-gateway/src/api/inbox/inbox.service.ts
+++ b/apps/api-gateway/src/api/inbox/inbox.service.ts
@@ -27,4 +27,8 @@ export class InboxService {
   async getSpams(userId: string) {
     return lastValueFrom(this.inboxClient.send({ cmd: 'get-spams' }, { userId }));
   }
+
+  async getSubscriptionsList() {
+    return lastValueFrom(this.inboxClient.send({ cmd: 'get-subscriptions-list' }, {}));
+  }
 }

--- a/apps/inbox/src/inbox.controller.ts
+++ b/apps/inbox/src/inbox.controller.ts
@@ -68,4 +68,12 @@ export class InboxController {
       spams: res,
     };
   }
+
+  @MessagePattern({ cmd: 'get-subscriptions-list' })
+  async getSubscriptionsList() {
+    const res = await this.inboxReadService.getSubscriptionsList();
+    return {
+      subscriptions: res,
+    };
+  }
 }

--- a/apps/inbox/src/inbox.module.ts
+++ b/apps/inbox/src/inbox.module.ts
@@ -5,9 +5,9 @@ import { MongoModule } from './mongo/mongo.module';
 import { InboxReadService } from './services/inbox-read.service';
 import { InboxUpdateService } from './services/inbox-update.service';
 import { InboxCreateService } from './services/inbox-create.service';
-
+import { ConstantsModule } from '@libs/common';
 @Module({
-  imports: [MongoModule],
+  imports: [MongoModule, ConstantsModule],
   controllers: [InboxController],
   providers: [InboxCreateService, InboxReadService, InboxUpdateService],
 })

--- a/apps/inbox/src/services/inbox-read.service.ts
+++ b/apps/inbox/src/services/inbox-read.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InboxRepository } from '../mongo/repositories/inbox.repository';
-
+import { SubscriptionListConstants } from '@libs/common';
 @Injectable()
 export class InboxReadService {
-  constructor(private readonly inboxRepository: InboxRepository) {}
+  constructor(
+    private readonly inboxRepository: InboxRepository,
+    private readonly subscriptionList: SubscriptionListConstants,
+  ) {}
 
   async getSubscriptions(userId: string) {
     const inbox = await this.inboxRepository.findInboxByUserId(userId);
@@ -32,5 +35,9 @@ export class InboxReadService {
         address: spam,
       };
     });
+  }
+
+  async getSubscriptionsList() {
+    return this.subscriptionList.subscriptionList;
   }
 }

--- a/libs/common/src/constants/constants.module.ts
+++ b/libs/common/src/constants/constants.module.ts
@@ -2,10 +2,13 @@ import { Module } from '@nestjs/common';
 import { MailConstants } from './mail.constants';
 import { designatedMailSenders } from './designatedMailSenders';
 import { privateMailDomains } from './privateMailDomains';
+import { SubscriptionListConstants } from './subscription-list.constants';
+import { subscriptionNewsletterList } from './subscriptionNewsletterList';
 
 @Module({
   providers: [
     MailConstants,
+    SubscriptionListConstants,
     {
       provide: 'DESIGNATED_SENDERS',
       useValue: designatedMailSenders,
@@ -14,7 +17,11 @@ import { privateMailDomains } from './privateMailDomains';
       provide: 'PRIVATE_MAIL_DOMAINS',
       useValue: privateMailDomains,
     },
+    {
+      provide: 'SUBSCRIPTION_LIST',
+      useValue: subscriptionNewsletterList,
+    },
   ],
-  exports: [MailConstants],
+  exports: [MailConstants, SubscriptionListConstants],
 })
 export class ConstantsModule {}

--- a/libs/common/src/constants/subscription-list.constants.ts
+++ b/libs/common/src/constants/subscription-list.constants.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { SubscriptionList } from './subscriptionNewsletterList';
+
+@Injectable()
+export class SubscriptionListConstants {
+  constructor(
+    @Inject('SUBSCRIPTION_LIST')
+    private readonly subscriptionNewsletterList: SubscriptionList,
+  ) {}
+
+  get subscriptionList() {
+    return this.subscriptionNewsletterList;
+  }
+}

--- a/libs/common/src/constants/subscriptionNewsletterList.ts
+++ b/libs/common/src/constants/subscriptionNewsletterList.ts
@@ -1,0 +1,37 @@
+interface Newsletter {
+  name: string;
+  companyName: string;
+  isAutomated: boolean;
+  content: string;
+  link: string;
+}
+
+export interface SubscriptionList {
+  tech: Newsletter[];
+  business: Newsletter[];
+  health: Newsletter[];
+  trend: Newsletter[];
+  career: Newsletter[];
+  startup: Newsletter[];
+}
+
+const techNewsletterList: Newsletter[] = [];
+
+const businessNewsletterList: Newsletter[] = [];
+
+const designNewsletterList: Newsletter[] = [];
+
+const trendNewsletterList: Newsletter[] = [];
+
+const careerNewsletterList: Newsletter[] = [];
+
+const startupNewsletterList: Newsletter[] = [];
+
+export const subscriptionNewsletterList: SubscriptionList = {
+  tech: techNewsletterList,
+  business: businessNewsletterList,
+  health: designNewsletterList,
+  trend: trendNewsletterList,
+  career: careerNewsletterList,
+  startup: startupNewsletterList,
+};

--- a/libs/common/src/constants/subscriptionNewsletterList.ts
+++ b/libs/common/src/constants/subscriptionNewsletterList.ts
@@ -3,7 +3,8 @@ interface Newsletter {
   companyName: string;
   isAutomated: boolean;
   content: string;
-  link: string;
+  subscriptionLink: string;
+  contentLink: string;
 }
 
 export interface SubscriptionList {
@@ -15,17 +16,72 @@ export interface SubscriptionList {
   startup: Newsletter[];
 }
 
-const techNewsletterList: Newsletter[] = [];
+const techNewsletterList: Newsletter[] = [
+  {
+    name: 'FE News',
+    companyName: 'FE News',
+    isAutomated: false,
+    content:
+      '네이버 FE 엔지니어들이 엄선한 양질의 FE 및 주요한 기술 소식들을 큐레이션 해 공유하는 것을 목표로 합니다. 매월 첫째 주 수요일, 월 1회 발행 됩니다.',
+    subscriptionLink: 'https://fenews.substack.com/embed',
+    contentLink: 'https://github.com/naver/fe-news/blob/master/issues/2024-08.md',
+  },
+];
 
-const businessNewsletterList: Newsletter[] = [];
+const businessNewsletterList: Newsletter[] = [
+  {
+    name: '머니레터',
+    companyName: '어피티',
+    isAutomated: false,
+    content: '경제 공부, 선택 아닌 필수막막한 경제 공부, 머니레터로 시작하세요.',
+    subscriptionLink: 'https://uppity.co.kr/newsletter/money-letter/',
+    contentLink: 'https://uppity.co.kr/newsletter/money-letter/',
+  },
+];
 
-const designNewsletterList: Newsletter[] = [];
+const designNewsletterList: Newsletter[] = [
+  {
+    name: '디자인 나침반 뉴스레터',
+    companyName: '디자인 나침반',
+    isAutomated: false,
+    content: ' 매주 화요일 아침, 16년 차 디자이너가큐레이션한 디자인 트렌드를 모아보세요.',
+    subscriptionLink: 'https://designcompass.org/',
+    contentLink: 'https://designcompass.org/',
+  },
+];
 
-const trendNewsletterList: Newsletter[] = [];
+const trendNewsletterList: Newsletter[] = [
+  {
+    name: '캐릿',
+    companyName: '대학내일',
+    isAutomated: false,
+    content: 'MZ세대와 세 발 더 가까워질 수 있는 인사이트를 매주 화요일 출근 전에 쏴드립니다. 렛츠 캐릿!',
+    subscriptionLink: 'https://www.careet.net/Subscribe',
+    contentLink: 'https://universitytomorrow.com/',
+  },
+];
 
-const careerNewsletterList: Newsletter[] = [];
+const careerNewsletterList: Newsletter[] = [
+  {
+    name: '서핏',
+    companyName: '서핏',
+    isAutomated: false,
+    content: '스타트업 사람들을 위한 뉴스레터',
+    subscriptionLink: 'https://surfside.stibee.com/',
+    contentLink: 'https://surfside.stibee.com/',
+  },
+];
 
-const startupNewsletterList: Newsletter[] = [];
+const startupNewsletterList: Newsletter[] = [
+  {
+    name: '조쉬의 프로덕트 레터',
+    companyName: '조쉬의 프로덕트 레터',
+    isAutomated: false,
+    content: '퀄리티 있는 비즈니스, 프로덕트, 디자인, 1인 창업가 이야기를 주 1회 들려드릴게요.',
+    subscriptionLink: 'https://maily.so/josh',
+    contentLink: 'https://maily.so/josh',
+  },
+];
 
 export const subscriptionNewsletterList: SubscriptionList = {
   tech: techNewsletterList,

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -2,5 +2,6 @@ export * from './common.module';
 export * from './common.service';
 export * from './constants/constants.module';
 export * from './constants/mail.constants';
+export * from './constants/subscription-list.constants';
 export * from './exceptions/filter/custom-rpc.exception.filter';
 export * from './exceptions/filter/custom-axios.exception.filter';


### PR DESCRIPTION
## Issue Number
Inspo-117

## 작업 내용
- 뉴스레터 구독 리스트를 libs의 constant로 설정했습니다.
- inbox API 호출 시, constant로 지정한 값들이 json array 형태로 return 됩니다.

## Reference

## Check List
