### PR TITLE
[FEAT] newsletter list를 random하게 3개를 가져오는 API 구현

### DIFF
--- a/apps/api-gateway/src/api/inbox/inbox.controller.ts
+++ b/apps/api-gateway/src/api/inbox/inbox.controller.ts
@@ -43,8 +43,14 @@ export class InboxController {
   }
 
   @Get('/subscriptions-list')
-  async getSubscriptionsList() {
-    return await this.inboxService.getSubscriptionsList();
+  getSubscriptionsList() {
+    return this.inboxService.getSubscriptionsList();
+  }
+
+  @Get('/subscriptions-random-list')
+  async getSubscriptionsRandomList(@AuthInfo() authInfo: IAuthInfo) {
+    const { userId } = authInfo;
+    return await this.inboxService.getSubscriptionsRandomList(userId);
   }
 
   @Get('/groups')

--- a/apps/api-gateway/src/api/inbox/inbox.service.ts
+++ b/apps/api-gateway/src/api/inbox/inbox.service.ts
@@ -32,6 +32,16 @@ export class InboxService {
     return lastValueFrom(this.inboxClient.send({ cmd: 'get-subscriptions-list' }, {}));
   }
 
+  async getSubscriptionsRandomList(userId: string) {
+    const subscriptionRandomList = await lastValueFrom(this.inboxClient.send({ cmd: 'get-subscriptions-random-list' }, {}));
+    const userSubscriptionList = await lastValueFrom(this.inboxClient.send({ cmd: 'get-subscriptions' }, { userId }));
+
+    for (const subscription of subscriptionRandomList) {
+      subscription.isSubscribed = userSubscriptionList.some((userSub) => userSub.name === subscription.name);
+    }
+    return subscriptionRandomList;
+  }
+
   async getGroups(userId: string) {
     return lastValueFrom(this.inboxClient.send({ cmd: 'get-groups' }, { userId }));
   }

--- a/apps/inbox/src/inbox.controller.ts
+++ b/apps/inbox/src/inbox.controller.ts
@@ -81,4 +81,12 @@ export class InboxController {
       subscriptions: res,
     };
   }
+
+  @MessagePattern({ cmd: 'get-subscriptions-random-list' })
+  async getSubscriptionsRandomList() {
+    const res = await this.inboxReadService.getSubscriptionsRandomList();
+    return {
+      subscriptions: res,
+    };
+  }
 }

--- a/apps/inbox/src/services/inbox-read.service.ts
+++ b/apps/inbox/src/services/inbox-read.service.ts
@@ -49,4 +49,10 @@ export class InboxReadService {
   async getSubscriptionsList() {
     return this.subscriptionList.subscriptionList;
   }
+
+  async getSubscriptionsRandomList() {
+    const simpleSubscriptionList = this.subscriptionList.simpleSubscriptionList;
+    const randomList = simpleSubscriptionList.sort(() => 0.5 - Math.random()).slice(0, 3);
+    return randomList;
+  }
 }

--- a/libs/common/src/constants/constants.module.ts
+++ b/libs/common/src/constants/constants.module.ts
@@ -4,6 +4,7 @@ import { designatedMailSenders } from './designatedMailSenders';
 import { privateMailDomains } from './privateMailDomains';
 import { SubscriptionListConstants } from './subscription-list.constants';
 import { subscriptionNewsletterList } from './subscriptionNewsletterList';
+import { subscriptionSimpleNewsletterList } from './subscriptionSimpleNewsletterList';
 
 @Module({
   providers: [
@@ -20,6 +21,10 @@ import { subscriptionNewsletterList } from './subscriptionNewsletterList';
     {
       provide: 'SUBSCRIPTION_LIST',
       useValue: subscriptionNewsletterList,
+    },
+    {
+      provide: 'SIMPLE_SUBSCRIPTION_LIST',
+      useValue: subscriptionSimpleNewsletterList,
     },
   ],
   exports: [MailConstants, SubscriptionListConstants],

--- a/libs/common/src/constants/subscription-list.constants.ts
+++ b/libs/common/src/constants/subscription-list.constants.ts
@@ -1,14 +1,21 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { SubscriptionList } from './subscriptionNewsletterList';
+import { SimpleNewsletter } from './subscriptionSimpleNewsletterList';
 
 @Injectable()
 export class SubscriptionListConstants {
   constructor(
     @Inject('SUBSCRIPTION_LIST')
     private readonly subscriptionNewsletterList: SubscriptionList,
+    @Inject('SIMPLE_SUBSCRIPTION_LIST')
+    private readonly subscriptionSimpleNewsletterList: SimpleNewsletter[],
   ) {}
 
   get subscriptionList() {
     return this.subscriptionNewsletterList;
+  }
+
+  get simpleSubscriptionList() {
+    return this.subscriptionSimpleNewsletterList;
   }
 }

--- a/libs/common/src/constants/subscriptionSimpleNewsletterList.ts
+++ b/libs/common/src/constants/subscriptionSimpleNewsletterList.ts
@@ -1,0 +1,198 @@
+export interface SimpleNewsletter {
+  name: string;
+  isAutomated: boolean;
+  thumbnailImage: string;
+}
+
+export const subscriptionSimpleNewsletterList: SimpleNewsletter[] = [
+  {
+    name: 'Naver FE News',
+    isAutomated: false,
+    thumbnailImage: '',
+  },
+  {
+    name: '요즘 IT',
+    isAutomated: false,
+    thumbnailImage: 'https://yozm.wishket.com/static/renewal/img/news/og-img-main.png',
+  },
+  {
+    name: '뭐지 뉴스레터',
+    isAutomated: false,
+    thumbnailImage: 'https://moji.or.kr/new_logo_text.svg',
+  },
+  {
+    name: 'GeekNews',
+    isAutomated: false,
+    thumbnailImage:
+      'https://app.heybunny.io/_next/image?url=https%3A%2F%2Fassets.heybunny.io%2Fnewsletter%2Fweb%2Fgeeknews.png&w=3840&q=75',
+  },
+  {
+    name: '팁스터',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.maily.so/mailydfd3985cf89c8dd5ed873917477ed7c61627967836',
+  },
+  {
+    name: '일분톡',
+    isAutomated: false,
+    thumbnailImage: 'https://t1.daumcdn.net/news/202311/06/ilbuntok/20231106110238888fodm.png',
+  },
+  {
+    name: '죠스레터',
+    isAutomated: false,
+    thumbnailImage: 'https://www.jawsletter.blog/content/images/size/w256h256/2024/03/character2.png',
+  },
+  {
+    name: '어피티',
+    isAutomated: false,
+    thumbnailImage:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOkAAACUCAMAAABBVf7OAAAAbFBMVEX/IiL/////AAD/qan/0dH/9vb/bm7/Hh7/YWH/4uL/enr/Cwv/LCz/3Nz/ZGT//Pz/ior/R0f/GBj/w8P/7+//PDz/nZ3/k5P/y8v/XFz/hob/1tb/QkL/NDT/WFj/uLj/UVH/r6//gID/o6P43nXFAAAECElEQVR4nO3c23KqMBSAYViCgOEgIRwUELHv/44bULuT4ITOnu6xK13/RVudXvgNB0MMOg5FURRFURRFURRFURRFURRF/c84bPTuF/hd8W5n7mgLFUbXnMj5u1/j9wTehtQP2btf4/cEDUlJijWS2i1NEnH/I2qF3dLLtVp+i30+2C29Qblsy4qD5dtUgPMx206wt+A4ZfoAvpXOPnsIfdcdYojwS/m19ZSiTJJG0A9udoCTBedeeWuty1I4uEWpbGe00sQkdRMom3rZhW2X+ilcrupgwlKpWwCHk5CfsVUanRiM8knKWmk2Qq7+i63SafdN1dOzBdKorj4rrJaOwDkPnGD6CTerpQX0fe9wZ/oZ1xZIAzX9OK2nQZEVx2kQxGqBr8Jq2CvvKW4THDBKg+CYqGnQtdT19ccopLxsXXNrqR5Jf1YkJelLafpbpFmJ4VPFf5G2R6Uaxc6rSofnk1fPII0u2twhCqgmZU48DenjIG9M0hMOmpYiFU3hlXDwCs+3QMqZEpTagD6HauM4RSLlXapWa+PclbSpB4xSXo6RmlBda+kqHFIWGmforZJuzYeRlKQ/NZKapJmv1nQYBvSK1E/aqUT5JHgtzXYHtRzDJlWlXrwM0C+jb5J6nTagx7BFdWnJLqdTCVA9qCKJRAfHaTwh2T2ca1o1KSRJ4p2Zc79Iy8ZLmDqsTMNwwCfVF6KcIkU6/4pS+FgO1awCxnjAGbARnRQu2ulEHq1P0vlRVsPZf+y9zwQ2Kb8m2luEfJ79Kz3qE/fyf6GQsr1+qaIY7ntv28FgmBOzRDoURe1AZ7rAsUMaLBNevXEBrx3S+f00PJsHiHZIQfhiY9oapTSbU6UvZEKbfqn64N2ML6RIk9sy4z74knS9QcUhVGbUwh7DJlWlw32UFH8+91LqgTpNyjBsUU1aQFx9VCl8Lrd+KW1QXJOt0qTdfKDWwXMFb9MjluoDel06H4gX2N2fiPb5CopFyva1+omfPPh5SN3QOFOEQ8pebKOVNMqNN5TikMq3dryUCiGim3yri63SeJ7vAvM0px3SZUCfV8bxnx3SfjeOg2ce6Noh7bZG8yil/vO2ySTJTFKhLZDco5Me2WOVdVAWBmmiL3rlKMa5svT8XIAMgUk6nabU3m34Wq+ljln67hf9T21Jr79EKsZiBbVT+jKS/vBISlKS/vx+p7R+PPAhlhZgZ5H6DQYejnnrVbJ0GhEtwh3069ltbAtRVilXbTGERdvuGJylTbrDubOuUq7Ehx5gnv5Nhe3SrDhfujyt5ClfO6XzajnPUz/Xt1W6jqToIilJ8bYtHS2RsuuG1K8skTpQmb9TuEJxT+yX2vqeaGugFEVRFEVRFEVRFEVRFEVR1Pv7Az9ZWog4v77uAAAAAElFTkSuQmCC',
+  },
+  {
+    name: '뉴닉 데일리',
+    isAutomated: false,
+    thumbnailImage:
+      'https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/cnB6/image/IhsF3EupicqXfXqXn4YmNPBgeIk.png',
+  },
+  {
+    name: '부딩',
+    isAutomated: false,
+    thumbnailImage:
+      'https://static.wixstatic.com/media/6cb3fa_7a010a4bed4847cf942d1fadeeb58cda~mv2.jpg/v1/fill/w_640,h_220,al_c,q_80,usm_0.66_1.00_0.01,enc_auto/6cb3fa_7a010a4bed4847cf942d1fadeeb58cda~mv2.jpg',
+  },
+  {
+    name: '미스터동',
+    isAutomated: false,
+    thumbnailImage:
+      'https://static.wixstatic.com/media/6cb3fa_7a010a4bed4847cf942d1fadeeb58cda~mv2.jpg/v1/fill/w_640,h_220,al_c,q_80,usm_0.66_1.00_0.01,enc_auto/6cb3fa_7a010a4bed4847cf942d1fadeeb58cda~mv2.jpg',
+  },
+  {
+    name: '순살브리핑',
+    isAutomated: false,
+    thumbnailImage: 'https://yt3.googleusercontent.com/ytc/AIdro_lMar43mGyvDkwpYrlBmk9iqVrKDX1uKxwWCzB1IHyew2k=s900-c-k-c0x00ffffff-no-rj',
+  },
+  {
+    name: '디그',
+    isAutomated: false,
+    thumbnailImage: 'https://s3.ap-northeast-2.amazonaws.com/img.stibee.com/a82ab710-ca85-4f2e-bda8-3c7abcbad46a.png',
+  },
+  {
+    name: '너겟레터',
+    isAutomated: false,
+    thumbnailImage: 'https://img.stibee.com/b49d7b21-1aad-4e17-ba8d-05fe317d162f.jpg',
+  },
+  {
+    name: '커피팟',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.imweb.me/upload/S20191122814e60292f7a5/71c918a03846e.png',
+  },
+  {
+    name: '디자인 나침반 뉴스레터',
+    isAutomated: false,
+    thumbnailImage: '',
+  },
+  {
+    name: 'MSV 임팩트레터',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.imweb.me/thumbnail/20230327/142a114118c84.png',
+  },
+  {
+    name: '텔유어월드',
+    isAutomated: false,
+    thumbnailImage: 'https://img.stibee.com/ce6709c2-26cd-4388-bcfc-80fa1c267b4a.jpg',
+  },
+  {
+    name: '아트레터',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.imweb.me/thumbnail/20240825/9a391319747ef.png',
+  },
+  {
+    name: 'from.designer',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.maily.so/maily96b1a25984762d02e6b644e5b3ebf3321617349721',
+  },
+  {
+    name: '캐릿',
+    isAutomated: false,
+    thumbnailImage: 'https://img.stibee.com/66918_1676014333.png',
+  },
+  {
+    name: '은하맨숀',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.maily.so/202405/1714788595415344.png',
+  },
+  {
+    name: '미라클레터',
+    isAutomated: false,
+    thumbnailImage: 'https://wimg.mk.co.kr/svc/newsletter/product/202311/02/a5f311db-0b6a-41ef-805c-71582823396f.jpg',
+  },
+  {
+    name: '어거스트',
+    isAutomated: false,
+    thumbnailImage: 'https://s3.ap-northeast-2.amazonaws.com/img.stibee.com/ec66e8cd-0ed0-4e1a-b60e-80697b8e03b3.png',
+  },
+  {
+    name: '트렌드 라이트',
+    isAutomated: false,
+    thumbnailImage:
+      'https://media.licdn.com/dms/image/D4E16AQF2_AtqtMnD9w/profile-displaybackgroundimage-shrink_200_800/0/1665629374336?e=2147483647&v=beta&t=5hTYVGo_0eUx_VFGlPSbwlauLyw-DfoFyg-5J-t-lg8',
+  },
+  {
+    name: '서핏',
+    isAutomated: false,
+    thumbnailImage: 'https://www.surfit.io/assets/img/bi/symbol-mark-light-bg.png',
+  },
+  {
+    name: '점선면',
+    isAutomated: false,
+    thumbnailImage:
+      'https://app.heybunny.io/_next/image?url=https%3A%2F%2Fimages.heybunny.io%2Flarge%2F1711934366133-%ED%9D%B0%EB%B0%B0%EA%B2%BD_%EA%B3%B5%EC%9A%A9%EB%A1%9C%EA%B3%A0.png&w=3840&q=75',
+  },
+  {
+    name: '당근메일',
+    isAutomated: false,
+    thumbnailImage:
+      'https://oopy.lazyrockets.com/api/v2/notion/image?src=https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F0a466fc4-9e99-44ce-b469-bb14a2b2cbc7%2FLogo_Copy_3.png&blockId=0a32d27b-3b47-41bd-aadd-fcb71689dc0c&width=256',
+  },
+  {
+    name: '폴인',
+    isAutomated: false,
+    thumbnailImage: 'https://www.folin.co/api/folin.jpg',
+  },
+  {
+    name: '커리업',
+    isAutomated: false,
+    thumbnailImage: 'https://careerup.hankookilbo.com/assets2/careerup-default-thumbs.jpg',
+  },
+  {
+    name: '조쉬의 프로덕트 레터',
+    isAutomated: false,
+    thumbnailImage: '',
+  },
+  {
+    name: '스타트업 위클리',
+    isAutomated: false,
+    thumbnailImage:
+      'https://img1.daumcdn.net/thumb/R1280x0.fpng/?fname=http://t1.daumcdn.net/brunch/service/user/zIH/image/5sCKxNn2pgDIdcO7SHGa4J18opg.png',
+  },
+  {
+    name: '스타트업 위클리',
+    isAutomated: false,
+    thumbnailImage:
+      'https://img1.daumcdn.net/thumb/R1280x0.fpng/?fname=http://t1.daumcdn.net/brunch/service/user/zIH/image/5sCKxNn2pgDIdcO7SHGa4J18opg.png',
+  },
+  {
+    name: '아웃스탠딩',
+    isAutomated: false,
+    thumbnailImage: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTX4obITfK2yDzS4mgu5KIaAUgY0ao7xduYlA&s',
+  },
+  {
+    name: 'EO뉴스레터',
+    isAutomated: false,
+    thumbnailImage: 'https://img.stibee.com/37f43248-31f4-4d8f-ab64-af1808f88cf7.jpg',
+  },
+  {
+    name: 'PRODUCT LAB',
+    isAutomated: false,
+    thumbnailImage: 'https://cdn.maily.so/202207/1659078150169935.jpeg',
+  },
+];


### PR DESCRIPTION
## Issue Number
feat

## 작업 내용
- newsletter list를 random하게 3개 가져오는 API 구현했습니다.
  - user가 구독한 뉴스레터인지 비교 후 isSubscribe 의 boolean을 추가해 리턴합니다.
 
## Reference

## Check List
