### PR TITLE
모든 에러를 잡아서 로그 찍고 custom rpc error를 던지는 exceptionfilter정의

### DIFF
--- a/apps/mail-integrator/src/all.exception.filter.ts
+++ b/apps/mail-integrator/src/all.exception.filter.ts
@@ -1,0 +1,21 @@
+import { Catch, ArgumentsHost, ExceptionFilter } from '@nestjs/common';
+import { CustomRpcException } from '@libs/common';
+
+// TODO: common libs 하위로 대체
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  catch(exception: Error, host: ArgumentsHost) {
+    const ctx = host.switchToRpc();
+    const data = ctx.getData();
+
+    const response = {
+      status: 'error',
+      message: exception.message || 'Internal server error',
+      data,
+    };
+
+    console.error('**** AllExceptionsFilter -> catch Excption ****\n', response);
+
+    throw new CustomRpcException(response.message, 500);
+  }
+}

--- a/apps/mail-integrator/src/mail-integrator.controller.ts
+++ b/apps/mail-integrator/src/mail-integrator.controller.ts
@@ -1,26 +1,15 @@
 import { Controller } from '@nestjs/common';
 
 import { MailIntegratorService } from './mail-integrator.service';
-import { ClientProxy, ClientProxyFactory, MessagePattern, Transport } from '@nestjs/microservices';
+import { MessagePattern } from '@nestjs/microservices';
 import { InboxClient } from '@libs/network/dist';
-import { lastValueFrom } from 'rxjs';
 
 @Controller()
 export class MailIntegratorController {
-  // URGENT: client proxy -> network client로 변경
-  private client: ClientProxy;
   constructor(
     private readonly mailIntegratorService: MailIntegratorService,
     private readonly inboxClient: InboxClient,
-  ) {
-    this.client = ClientProxyFactory.create({
-      transport: Transport.TCP,
-      options: {
-        host: process.env.INBOX_SERVICE_HOST,
-        port: parseInt(process.env.INBOX_SERVICE_PORT),
-      },
-    });
-  }
+  ) {}
 
   @MessagePattern({ cmd: 'get-mail-senders' })
   async getMailSenders(data: { userId: string }) {

--- a/apps/mail-integrator/src/main.ts
+++ b/apps/mail-integrator/src/main.ts
@@ -1,8 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { MailIntegratorModule } from './mail-integrator.module';
-import { CustomRpcExceptionFilter } from '@libs/common';
-import { CustomAxiosExceptionFilter } from '@libs/common';
+import { CustomRpcExceptionFilter, CustomAxiosExceptionFilter } from '@libs/common';
+// TODO: common libs 하위의 filter로 대체
+import { AllExceptionsFilter } from './all.exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(MailIntegratorModule, {
@@ -14,6 +15,8 @@ async function bootstrap() {
   });
   app.useGlobalFilters(new CustomRpcExceptionFilter());
   app.useGlobalFilters(new CustomAxiosExceptionFilter());
+  app.useGlobalFilters(new AllExceptionsFilter());
+
   await app.listen();
 }
 bootstrap();

--- a/libs/common/src/exceptions/filter/all.exceptions.filter.ts
+++ b/libs/common/src/exceptions/filter/all.exceptions.filter.ts
@@ -1,0 +1,20 @@
+import { Catch, ArgumentsHost, ExceptionFilter } from '@nestjs/common';
+import { CustomRpcException } from './custom-rpc.exception';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  catch(exception: Error, host: ArgumentsHost) {
+    const ctx = host.switchToRpc();
+    const data = ctx.getData();
+
+    const response = {
+      status: 'error',
+      message: exception.message || 'Internal server error',
+      data,
+    };
+
+    console.error('**** AllExceptionsFilter -> catch Excption ****\n', response);
+
+    throw new CustomRpcException(response.message, 500);
+  }
+}

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -5,6 +5,7 @@ export * from './constants/mail.constants';
 export * from './constants/subscription-list.constants';
 export * from './exceptions/filter/custom-rpc.exception.filter';
 export * from './exceptions/filter/custom-axios.exception.filter';
+export * from './exceptions/filter/all.exceptions.filter';
 
 export * from './exceptions/filter/custom-axios.exception';
 export * from './exceptions/filter/custom-rpc.exception';

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -5,3 +5,6 @@ export * from './constants/mail.constants';
 export * from './constants/subscription-list.constants';
 export * from './exceptions/filter/custom-rpc.exception.filter';
 export * from './exceptions/filter/custom-axios.exception.filter';
+
+export * from './exceptions/filter/custom-axios.exception';
+export * from './exceptions/filter/custom-rpc.exception';


### PR DESCRIPTION
## Issue Number

## 작업 내용
모든 에러를 잡아서 로그 찍고 custom rpc error를 던지는 exceptionfilter정의

근데 common 하위에서 지금 export가 안되어서, 일단 이용하게될 mail-integrator 하위에도 새로 정의함. 
빌드해도 인식을 못하던데, 추후에 다시 수정할게요 

## Reference

## Check List
